### PR TITLE
add support for cycling activities

### DIFF
--- a/lib/postrunner/ActivitySummary.rb
+++ b/lib/postrunner/ActivitySummary.rb
@@ -81,25 +81,26 @@ module PostRunner
               "#{session.avg_heart_rate} bpm" : '-' ])
       t.row([ 'Max. HR:', session.max_heart_rate ?
               "#{session.max_heart_rate} bpm" : '-' ])
-			if @activity.sport == 'running' || @sport == 'multisport'
-				t.row([ 'Avg. Run Cadence:',
-								session.avg_running_cadence ?
-								"#{(2 * session.avg_running_cadence).round} spm" : '-' ])
-				t.row([ 'Avg. Vertical Oscillation:',
-								local_value(session, 'avg_vertical_oscillation', '%.1f %s',
-														{ :metric => 'cm', :statute => 'in' }) ])
-				t.row([ 'Avg. Ground Contact Time:',
-								session.avg_stance_time ?
-								"#{session.avg_stance_time.round} ms" : '-' ])
-				t.row([ 'Avg. Stride Length:',
-								local_value(session, 'avg_stride_length', '%.2f %s',
-														{ :metric => 'm', :statute => 'ft' }) ])
-			end
-			if @activity.sport == 'cycling'
-				t.row([ 'Avg. Cadence:',
-								session.avg_candence ?
-								"#{(2 * session.avg_candence).round} rpm" : '-' ])
-			end
+      if @activity.sport == 'running' || @sport == 'multisport'
+        t.row([ 'Avg. Run Cadence:',
+                session.avg_running_cadence ?
+                "#{(2 * session.avg_running_cadence).round} spm" : '-' ])
+        t.row([ 'Avg. Vertical Oscillation:',
+                local_value(session, 'avg_vertical_oscillation', '%.1f %s',
+                            { :metric => 'cm', :statute => 'in' }) ])
+        t.row([ 'Avg. Ground Contact Time:',
+                session.avg_stance_time ?
+                "#{session.avg_stance_time.round} ms" : '-' ])
+        t.row([ 'Avg. Stride Length:',
+                local_value(session, 'avg_stride_length', '%.2f %s',
+                            { :metric => 'm', :statute => 'ft' }) ])
+      end
+      if @activity.sport == 'cycling'
+        t.row([ 'Avg. Cadence:',
+                session.avg_candence ?
+                "#{(2 * session.avg_candence).round} rpm" : '-' ])
+      end
+
       t.row([ 'Training Effect:', session.total_training_effect ?
               session.total_training_effect : '-' ])
 

--- a/lib/postrunner/ActivitySummary.rb
+++ b/lib/postrunner/ActivitySummary.rb
@@ -81,19 +81,25 @@ module PostRunner
               "#{session.avg_heart_rate} bpm" : '-' ])
       t.row([ 'Max. HR:', session.max_heart_rate ?
               "#{session.max_heart_rate} bpm" : '-' ])
-      t.row([ 'Avg. Run Cadence:',
-              session.avg_running_cadence ?
-              "#{(2 * session.avg_running_cadence).round} spm" : '-' ])
-      t.row([ 'Avg. Vertical Oscillation:',
-              local_value(session, 'avg_vertical_oscillation', '%.1f %s',
-                          { :metric => 'cm', :statute => 'in' }) ])
-      t.row([ 'Avg. Ground Contact Time:',
-              session.avg_stance_time ?
-              "#{session.avg_stance_time.round} ms" : '-' ])
-      t.row([ 'Avg. Stride Length:',
-              local_value(session, 'avg_stride_length', '%.2f %s',
-                          { :metric => 'm', :statute => 'ft' }) ])
-
+			if @activity.sport == 'running' || @sport == 'multisport'
+				t.row([ 'Avg. Run Cadence:',
+								session.avg_running_cadence ?
+								"#{(2 * session.avg_running_cadence).round} spm" : '-' ])
+				t.row([ 'Avg. Vertical Oscillation:',
+								local_value(session, 'avg_vertical_oscillation', '%.1f %s',
+														{ :metric => 'cm', :statute => 'in' }) ])
+				t.row([ 'Avg. Ground Contact Time:',
+								session.avg_stance_time ?
+								"#{session.avg_stance_time.round} ms" : '-' ])
+				t.row([ 'Avg. Stride Length:',
+								local_value(session, 'avg_stride_length', '%.2f %s',
+														{ :metric => 'm', :statute => 'ft' }) ])
+			end
+			if @activity.sport == 'cycling'
+				t.row([ 'Avg. Cadence:',
+								session.avg_candence ?
+								"#{(2 * session.avg_candence).round} rpm" : '-' ])
+			end
       t.row([ 'Training Effect:', session.total_training_effect ?
               session.total_training_effect : '-' ])
 

--- a/lib/postrunner/ChartView.rb
+++ b/lib/postrunner/ChartView.rb
@@ -50,10 +50,10 @@ module PostRunner
         #chart_div(doc, 'hrv_score', 'HRV Score (30s Window)')
       end
       if @sport == 'running' || @sport == 'multisport'
-				chart_div(doc, 'run_cadence', 'Run Cadence (spm)')
+        chart_div(doc, 'run_cadence', 'Run Cadence (spm)')
       end
       if @sport == 'cycling'
-				chart_div(doc, 'cadence', 'Cadence (rpm)')
+        chart_div(doc, 'cadence', 'Cadence (rpm)')
       end
       chart_div(doc, 'vertical_oscillation',
                 "Vertical Oscillation (#{select_unit('cm')})")

--- a/lib/postrunner/ChartView.rb
+++ b/lib/postrunner/ChartView.rb
@@ -49,7 +49,12 @@ module PostRunner
         chart_div(doc, 'hrv', 'R-R Intervals/Heart Rate Variability (ms)')
         #chart_div(doc, 'hrv_score', 'HRV Score (30s Window)')
       end
-      chart_div(doc, 'run_cadence', 'Run Cadence (spm)')
+      if @sport == 'running' || @sport == 'multisport'
+				chart_div(doc, 'run_cadence', 'Run Cadence (spm)')
+      end
+      if @sport == 'cycling'
+				chart_div(doc, 'cadence', 'Cadence (rpm)')
+      end
       chart_div(doc, 'vertical_oscillation',
                 "Vertical Oscillation (#{select_unit('cm')})")
       chart_div(doc, 'stance_time', 'Ground Contact Time (ms)')
@@ -116,12 +121,17 @@ EOT
         s << line_graph('hrv', 's', '', '#900000')
         #s << line_graph('hrv_score', 'HRV Score', '', '#900000')
       end
+      if @sport == 'running' || @sport == 'multisport'
       s << point_graph('run_cadence', 'Run Cadence', 'spm',
                        [ [ '#EE3F2D', 151 ],
                          [ '#F79666', 163 ],
                          [ '#A0D488', 174 ],
                          [ '#96D7DE', 185 ],
                          [ '#A88BBB', nil ] ])
+      end
+      if @sport == 'cycling'
+        s << line_graph('cadence', 'Cadence', 'rpm', '#A88BBB')
+      end
       s << point_graph('vertical_oscillation', 'Vertical Oscillation', 'cm',
                        [ [ '#A88BBB', 67 ],
                          [ '#96D7DE', 84 ],


### PR DESCRIPTION
- linegraph for cadence
- RPM instead of SPM
- use avg_candence attribute instead of avg_running_cadence

By the way, there "candence" is probably a typo to fix in fit4ruby :)
