### PR TITLE
Update dependencies. Test via github actions on various rubies

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,33 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Ruby
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu]
+        ruby: [2.4, 2.5, 2.6, 2.7, 3.0, head]
+    continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+
+    - name: Test with RSpec
+      run: bundle exec rspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,24 +1,9 @@
-$:.unshift File.join(File.dirname(__FILE__))
-
-# Add the lib directory to the search path if it isn't included already
-lib = File.expand_path('../lib', __FILE__)
-$:.unshift lib unless $:.include?(lib)
-
+#!/usr/bin/env ruby
+require_relative 'lib/postrunner/version'
+require 'rake'
+require 'rspec'
 require "bundler/gem_tasks"
-require "rspec/core/rake_task"
-require 'rake/clean'
-require 'yard'
-YARD::Rake::YardocTask.new
+require 'rspec/core/rake_task'
 
-Dir.glob( 'tasks/*.rake').each do |fn|
-  begin 
-    load fn;
-  rescue LoadError
-    puts "#{fn.split('/')[1]} tasks unavailable: #{$!}"
-  end
-end
-
-task :default  => :spec
-task :test => :spec
-
-desc 'Run all unit and spec tests'
+RSpec::Core::RakeTask.new(:spec)
+ 

--- a/postrunner.gemspec
+++ b/postrunner.gemspec
@@ -30,10 +30,10 @@ operating systems as well.}
 
   spec.add_dependency 'fit4ruby', '~> 3.8.0'
   spec.add_dependency 'perobs', '~> 4.3.0'
-  spec.add_dependency 'nokogiri', '~> 1.10.10'
+  spec.add_dependency 'nokogiri'
 
-  spec.add_development_dependency 'bundler', '~> 1.6'
-  spec.add_development_dependency 'rake', '~> 13.0.3'
-  spec.add_development_dependency 'rspec', '~> 3.6.0'
-  spec.add_development_dependency 'yard', '~> 0.9.20'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'yard'
 end


### PR DESCRIPTION
I still have the problem being unable to update the old PEROBS database (I can live with loosing the old data).

Here is my first patch, to ensure, that the gem works with various versions of ruby and that the spec tests will be run for each commit and pull request.

It could be extended to run under MacOSX and Windows, but I am interested in working for non free OS.