### PR TITLE
correct average cadence for cycling

### DIFF
--- a/lib/postrunner/ActivitySummary.rb
+++ b/lib/postrunner/ActivitySummary.rb
@@ -116,7 +116,7 @@ module PostRunner
       if @activity.sport == 'cycling'
         t.row([ 'Avg. Cadence:',
                 session.avg_cadence ?
-                "#{(2 * session.avg_cadence).round} rpm" : '-' ])
+                "#{(session.avg_cadence).round} rpm" : '-' ])
       end
       t.row([ 'Total Ascent:',
               local_value(session, 'total_ascent', '%.0f %s',


### PR DESCRIPTION
The avg_cadence field already contains the average cadence. There's no need to double the value.